### PR TITLE
Implement support for multiple documents in one file

### DIFF
--- a/secode/core.py
+++ b/secode/core.py
@@ -1,20 +1,24 @@
 import base64
+import sys
 
-from ruamel.yaml import RoundTripDumper, YAML, dump
+from ruamel.yaml import RoundTripDumper, YAML, dump_all
 
 
 def encode_secrets(file_path, decode=False):
     encoder = base64_decode if decode else base64_encode
     original_payload = read_yaml(file_path)
-    encoded_payload = encode(original_payload, encoder)
-    content = dump(encoded_payload, Dumper=RoundTripDumper)
-    return content
+    encoded_payload = []
+    for document in original_payload:
+        encoded_payload.append(encode(document, encoder))
+    return dump_all(encoded_payload, Dumper=RoundTripDumper)
 
 
 def read_yaml(file_path):
     with open(file_path, 'r') as stream:
         yaml = YAML()
-        return yaml.load(stream.read())
+        docs = yaml.load_all(stream.read())
+        for doc in docs:
+            yield doc
 
 
 def encode(payload, encoder):

--- a/tests/test_secode.py
+++ b/tests/test_secode.py
@@ -13,6 +13,10 @@ from secode.core import base64_decode, base64_encode
         'yamls/test_multiple.yaml',
         'yamls/test_multiple_base64.yaml'
     ),
+    (
+        'yamls/test_documents.yaml',
+        'yamls/test_documents_base64.yaml'
+    ),
 ])
 def test_encode_decode(file_path, file_path_expected):
     # encode

--- a/tests/yamls/test_documents.yaml
+++ b/tests/yamls/test_documents.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret_1
+type: Opaque
+data:
+  secret_val_1: this-is-secret-1
+  secret_val_2: 1337
+  secret_val_3: v/pp;QT(<!]h|F%@G5,9g,%qeh9j+ubQ3dM\x?z\Hu">a[T7CE8_jq6ao$|S!]kKt%ygDY3[x"Eq{c,,|)Me=5h!l;nT12L"0$~|<La!P&VM-4Kruf_xEVXC48Bn"wfrNdFGn~#"lSLLW\nbRFWW]IZkgkWar.6Xz;>"VUl'Cl@R-&\q-_gA6gFOe$vUX"/3O72qqeShZ.#ryHrNzqK$6(9o=v/cA0SS6Mu'2}YGw{)J4T
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret_2
+type: Opaque
+data:
+  secret_val_1: K2f+s}TB(9`VS!XQB|;l
+  secret_val_2: D98jx]z}>(W\G,b\VEj

--- a/tests/yamls/test_documents_base64.yaml
+++ b/tests/yamls/test_documents_base64.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret_1
+type: Opaque
+data:
+  secret_val_1: dGhpcy1pcy1zZWNyZXQtMQ==
+  secret_val_2: MTMzNw==
+  secret_val_3: di9wcDtRVCg8IV1ofEYlQEc1LDlnLCVxZWg5ait1YlEzZE1ceD96XEh1Ij5hW1Q3Q0U4X2pxNmFvJHxTIV1rS3QleWdEWTNbeCJFcXtjLCx8KU1lPTVoIWw7blQxMkwiMCR+fDxMYSFQJlZNLTRLcnVmX3hFVlhDNDhCbiJ3ZnJOZEZHbn4jImxTTExXXG5iUkZXV11JWmtna1dhci42WHo7PiJWVWwnQ2xAUi0mXHEtX2dBNmdGT2UkdlVYIi8zTzcycXFlU2haLiNyeUhyTnpxSyQ2KDlvPXYvY0EwU1M2TXUnMn1ZR3d7KUo0VA==
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret_2
+type: Opaque
+data:
+  secret_val_1: SzJmK3N9VEIoOWBWUyFYUUJ8O2w=
+  secret_val_2: RDk4anhden0+KFdcRyxiXFZFag==


### PR DESCRIPTION
Tests are passing:

```
$ pytest
================================================================================ test session starts ================================================================================
platform darwin -- Python 3.7.2, pytest-3.2.2, py-1.5.4, pluggy-0.4.0
rootdir: /Users/gpolek/secode, inifile:
plugins: testinfra-1.14.1
collected 5 items

test_secode.py .....

============================================================================= 5 passed in 0.41 seconds ==============================================================================
```