### PR TITLE
Upgrade ruamel-yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Also works with multiple `Secret` definitions per file - `kind: List` or  `---` 
 
 ## Install
 
-Using `pip`:
+Using `pip3`:
 
-`sudo pip install git+http://github.com/crtomirmajer/secode.git`
+`pip3 install git+http://github.com/crtomirmajer/secode.git`
 
 ## Usage
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         ],
     ),
     install_requires=[
-        'ruamel.yaml==0.15.80'
+        'ruamel.yaml~=0.16.12'
     ],
     extras_require={
         'unit-tests': [


### PR DESCRIPTION
Upgraded ruamel-yaml (0.15.80 did not seem to install with python 3.9 and pip 20.3).
Changed README.md to use `pip3`